### PR TITLE
Fix extra power menu button backgrounds

### DIFF
--- a/src/main/assets/overlays/android/res/values/styles.xml
+++ b/src/main/assets/overlays/android/res/values/styles.xml
@@ -8,8 +8,6 @@
         <item name="android:colorPrimaryDark">@*android:color/background_floating_material_dark</item>    <!--OG:@color/primary_dark_device_default_settings_light-->
         <item name="android:colorAccent">@*android:color/material_deep_teal_500</item>
         <item name="android:colorSecondary">@*android:color/background_material_dark</item> 	<!--OG:@color/secondary_device_default_settings_light-->
-        <!--QS Divider & Power Menu-->
-        <item name="android:backgroundTint">@*android:color/primary_material_dark</item>   <!--Self-defined-->
     </style>
 
     <!--Settings App-->

--- a/src/main/assets/overlays/com.android.systemui/res/values/styles.xml
+++ b/src/main/assets/overlays/com.android.systemui/res/values/styles.xml
@@ -25,4 +25,14 @@
     <style name="TextAppearance.NotificationInfo.Secondary.Link" parent="@style/TextAppearance.NotificationInfo.Secondary">
         <item name="android:textColor">@*android:color/material_deep_teal_500</item>   <!--OG:?android:colorAccent-->
     </style>
+
+    <style name="qs_theme" parent="@*com.android.systemui:style/qs_base">
+        <item name="*com.android.systemui:darkIconTheme">@*com.android.systemui:style/QSIconTheme</item>
+        <item name="*com.android.systemui:lightIconTheme">@*com.android.systemui:style/QSIconTheme</item>
+        <item name="android:colorPrimary">@*android:color/primary_material_dark</item>
+        <item name="android:colorPrimaryDark">@*android:color/primary_dark_material_dark</item>
+        <item name="android:colorAccent">@*android:color/material_deep_teal_500</item>
+        <item name="android:colorSecondary">@*android:color/primary_dark_material_dark</item>
+        <item name="android:colorControlNormal">@*android:color/material_deep_teal_500</item>
+    </style>
 </resources>


### PR DESCRIPTION
Extra buttons like emergency affordance and/or custom buttons
enabled via config end up with a transparent background without
these commits.

Fair warning, commit 92c32afae68d breaks the legacy alertdialog
style power menu.