### PR TITLE
Make settings actionbar dark when using search (P)

### DIFF
--- a/app/src/main/assets/overlays/com.android.settings/type3_Android_8,1/values/colors.xml
+++ b/app/src/main/assets/overlays/com.android.settings/type3_Android_8,1/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="bluetooth_dialog_text_color">#8affffff</color>   <!--OG:#8a000000-->
+	<color name="bluetooth_dialog_text_color">#8affffff</color>   <!--OG:#8a000000-->
     <!--OmniMeme Tears-->
     <color name="omni_logo_color">@*android:color/material_deep_teal_500</color>
     <!--Search Panel BG-->
@@ -9,7 +9,4 @@
     <color name="condition_card_background">@*android:color/background_holo_dark</color>   <!--OG:#fff8f8f8-->
     <color name="material_grey_300">@*android:color/background_material_dark</color>   <!--OG:#ffe0e0e0-->
     <color name="suggestion_condition_background">@*android:color/background_floating_material_dark</color>   <!--OG:#fff2f2f2-->
-    <!-- Expanded desktop -->
-    <drawable name="expanded_item_bg_activated">@android:color/background_material_dark</drawable>
-    <drawable name="expanded_item_bg">@*android:color/background_floating_material_dark</drawable>
 </resources>

--- a/app/src/main/assets/overlays/com.google.android.settings.intelligence/type3-common/values/colors.xml
+++ b/app/src/main/assets/overlays/com.google.android.settings.intelligence/type3-common/values/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="search_panel_background">#00000000</color>  <!--original value: #fff2f2f2-->
+    <color name="search_panel_background">@*android:color/transparent</color>  <!--original value: #fff2f2f2-->
 </resources>

--- a/app/src/main/assets/overlays/com.google.android.settings.intelligence/type3-common/values/colors.xml
+++ b/app/src/main/assets/overlays/com.google.android.settings.intelligence/type3-common/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="search_panel_background">@*android:color/background_material_dark</color>  <!--original value: #fff2f2f2-->
+</resources>

--- a/app/src/main/assets/overlays/com.google.android.settings.intelligence/type3-common/values/colors.xml
+++ b/app/src/main/assets/overlays/com.google.android.settings.intelligence/type3-common/values/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="search_panel_background">@*android:color/background_material_dark</color>  <!--original value: #fff2f2f2-->
+    <color name="search_panel_background">#00000000</color>  <!--original value: #fff2f2f2-->
 </resources>


### PR DESCRIPTION
Gets rid of the white actionbar in settings (P) after the searchbar is pressed. Works fine with Black/Dark options, but compatibility with Transparent might need some further improvement, as it clashes visually with the highly transparent search suggestions BG right underneath it. Better than white though.